### PR TITLE
Apply server-sanitized settings to JS client on saved

### DIFF
--- a/js/customize-setting-validation.js
+++ b/js/customize-setting-validation.js
@@ -80,7 +80,7 @@ wp.customize.settingValidation = (function( $, api ) {
 					validationMessageElement.slideDown( 'fast' );
 				}
 
-				control.container.toggleClass( 'customize-setting-invalid', 0 === validationMessages.length );
+				control.container.toggleClass( 'customize-setting-invalid', 0 !== validationMessages.length );
 				validationMessageElement.empty().append( $.trim(
 					self.validationMessageTemplate( { messages: validationMessages } )
 				) );

--- a/js/customize-setting-validation.js
+++ b/js/customize-setting-validation.js
@@ -179,6 +179,30 @@ wp.customize.settingValidation = (function( $, api ) {
 		// @todo Also display response.message somewhere.
 	};
 
+	/**
+	 * Apply saved sanitized values from server to settings in JS client, if different.
+	 *
+	 * @param {object} response
+	 * @param {object} response.sanitized_setting_values
+	 */
+	self.afterSaveSuccess = function ( response ) {
+		if ( ! response.sanitized_setting_values ) {
+			return;
+		}
+
+		var wasSaved = api.state( 'saved' ).get();
+
+		_.each( response.sanitized_setting_values, function ( value, id ) {
+			var setting = api( id );
+			if ( setting ) {
+				setting.set( value );
+				setting._dirty = false;
+			}
+		} );
+
+		api.state( 'saved' ).set( wasSaved );
+	};
+
 	api.bind( 'add', function( setting ) {
 		self.setupSettingForValidationMessage( setting );
 	} );
@@ -190,6 +214,9 @@ wp.customize.settingValidation = (function( $, api ) {
 	} );
 	api.bind( 'error', function( response ) {
 		self.afterSaveFailure( response );
+	} );
+	api.bind( 'saved', function( response ) {
+		self.afterSaveSuccess( response );
 	} );
 
 	return self;

--- a/js/customize-setting-validation.js
+++ b/js/customize-setting-validation.js
@@ -185,14 +185,15 @@ wp.customize.settingValidation = (function( $, api ) {
 	 * @param {object} response
 	 * @param {object} response.sanitized_setting_values
 	 */
-	self.afterSaveSuccess = function ( response ) {
+	self.afterSaveSuccess = function( response ) {
+		var wasSaved;
 		if ( ! response.sanitized_setting_values ) {
 			return;
 		}
 
-		var wasSaved = api.state( 'saved' ).get();
+		wasSaved = api.state( 'saved' ).get();
 
-		_.each( response.sanitized_setting_values, function ( value, id ) {
+		_.each( response.sanitized_setting_values, function( value, id ) {
 			var setting = api( id );
 			if ( setting ) {
 				setting.set( value );

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,14 @@ Core feature plugin for Customizer setting validation, error messaging, and tran
 ## Description ##
 
 This feature plugin allows setting values to be validated and for any validation errors to block the Customizer from
-saving any setting until all are valid. The functionality here will be proposed for inclusion in WordPress Core via
-Trac [#34893](https://core.trac.wordpress.org/ticket/34893): Improve Customizer setting validation model.
+saving any setting until all are valid. Additionally, once a successful save is performed on the server, any settings
+that have resulting PHP-sanitized values which differ from the JS values will be updated on the client to match, while
+retaining the non-dirty saved sate.
+
+The functionality here will be proposed for inclusion in WordPress Core via Trac [#34893](https://core.trac.wordpress.org/ticket/34893):
+Improve Customizer setting validation model.
+
+[![Play video on YouTube](https://i1.ytimg.com/vi/ZNk6FhtS8TM/hqdefault.jpg)](https://www.youtube.com/watch?v=ZNk6FhtS8TM)
 
 Settings in the Customizer rely on sanitization to ensure that only valid values get persisted to the database.
 The sanitization in the Customizer generally allows values to be passed through to be persisted and does not enforce
@@ -38,11 +44,15 @@ is that some settings would get saved, whereas others would not, and the user wo
 and which failed (again, since there is no standard mechanism for showing validation error message).
 The Customizer state would only partially get persisted to the database. This isn't good.
 
+Lastly, once the settings are successfully saved, if any of the PHP-sanitization differs in any way from the
+JS-sanitization on the client, the difference in value will not be apparent in the Customizer controls.
+
 So this plugin aims to solve both these problems by:
 
 * Validating settings on server before save.
 * Displaying validation error messages from server and from JS client.
 * Performing transactional/atomic setting saving, rejecting all settings if one is invalid.
+* Sync back the PHP-sanitized saved setting values to the JS client and ensure controls are populated with the actual persisted values.
 
 Note that the transactional/atomic saving here in setting validation is not the same as the
 [Customizer Transactions proposal](https://make.wordpress.org/core/2015/01/26/customizer-transactions-proposal/),

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ retaining the non-dirty saved sate.
 The functionality here will be proposed for inclusion in WordPress Core via Trac [#34893](https://core.trac.wordpress.org/ticket/34893):
 Improve Customizer setting validation model.
 
+See demo video “[Customize Validate Entitled Settings](https://gist.github.com/westonruter/1016332b18ee7946dec3)” plugin which forces the site title,
+widget titles, and nav menu item labels to all be populated and to start with an upper-case letter:
+
 [![Play video on YouTube](https://i1.ytimg.com/vi/ZNk6FhtS8TM/hqdefault.jpg)](https://www.youtube.com/watch?v=ZNk6FhtS8TM)
 
 Settings in the Customizer rely on sanitization to ensure that only valid values get persisted to the database.

--- a/readme.txt
+++ b/readme.txt
@@ -11,8 +11,14 @@ Core feature plugin for Customizer setting validation, error messaging, and tran
 == Description ==
 
 This feature plugin allows setting values to be validated and for any validation errors to block the Customizer from
-saving any setting until all are valid. The functionality here will be proposed for inclusion in WordPress Core via
-Trac [#34893](https://core.trac.wordpress.org/ticket/34893): Improve Customizer setting validation model.
+saving any setting until all are valid. Additionally, once a successful save is performed on the server, any settings
+that have resulting PHP-sanitized values which differ from the JS values will be updated on the client to match, while
+retaining the non-dirty saved sate.
+
+The functionality here will be proposed for inclusion in WordPress Core via Trac [#34893](https://core.trac.wordpress.org/ticket/34893):
+Improve Customizer setting validation model.
+
+[youtube https://youtu.be/ZNk6FhtS8TM]
 
 Settings in the Customizer rely on sanitization to ensure that only valid values get persisted to the database.
 The sanitization in the Customizer generally allows values to be passed through to be persisted and does not enforce
@@ -35,11 +41,15 @@ is that some settings would get saved, whereas others would not, and the user wo
 and which failed (again, since there is no standard mechanism for showing validation error message).
 The Customizer state would only partially get persisted to the database. This isn't good.
 
+Lastly, once the settings are successfully saved, if any of the PHP-sanitization differs in any way from the
+JS-sanitization on the client, the difference in value will not be apparent in the Customizer controls.
+
 So this plugin aims to solve both these problems by:
 
 * Validating settings on server before save.
 * Displaying validation error messages from server and from JS client.
 * Performing transactional/atomic setting saving, rejecting all settings if one is invalid.
+* Sync back the PHP-sanitized saved setting values to the JS client and ensure controls are populated with the actual persisted values.
 
 Note that the transactional/atomic saving here in setting validation is not the same as the
 [Customizer Transactions proposal](https://make.wordpress.org/core/2015/01/26/customizer-transactions-proposal/),

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,9 @@ retaining the non-dirty saved sate.
 The functionality here will be proposed for inclusion in WordPress Core via Trac [#34893](https://core.trac.wordpress.org/ticket/34893):
 Improve Customizer setting validation model.
 
+See demo video “[Customize Validate Entitled Settings](https://gist.github.com/westonruter/1016332b18ee7946dec3)” plugin which forces the site title,
+widget titles, and nav menu item labels to all be populated and to start with an upper-case letter:
+
 [youtube https://youtu.be/ZNk6FhtS8TM]
 
 Settings in the Customizer rely on sanitization to ensure that only valid values get persisted to the database.


### PR DESCRIPTION
If server-side sanitization modifies a value when saving, make sure that this modified value gets applied to the JS client and results in a non-dirty state.

(Note there a possibility of a race condition for widgets since they currently rely on a separate `update-widget` Ajax request to sanitize their values.)
